### PR TITLE
Fix build error in xcb-imdkit 1.0.9

### DIFF
--- a/source/xcb/display.c
+++ b/source/xcb/display.c
@@ -29,10 +29,9 @@
 /** Log domain for this module */
 #define G_LOG_DOMAIN "X11Helper"
 
-#ifdef XCB_IMDKIT
 #include <xcb-imdkit/encoding.h>
 #include <xcb/xcb_keysyms.h>
-#endif
+
 #include <cairo-xcb.h>
 #include <cairo.h>
 #include <config.h>


### PR DESCRIPTION

../rofi/source/xcb/display.c: In function ‘xcb_display_setup’:
../rofi/source/xcb/display.c:1678:3: error: implicit declaration of function ‘xcb_compound_text_init’ [-Wimplicit-function-declaration]
 1678 |   xcb_compound_text_init();
      |   ^~~~~~~~~~~~~~~~~~~~~~